### PR TITLE
security: require POSTGRES_PASSWORD from env (entry vector for compromise)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 POSTGRES_HOST=your-db-host.db.ondigitalocean.com
 POSTGRES_PORT=25060
 POSTGRES_USER=doadmin
-POSTGRES_PASSWORD=your-password-here
+POSTGRES_PASSWORD=__GENERATE_64_HEX_OPENSSL_RAND_HEX_32__
 POSTGRES_DB=defaultdb
 
 # These will be automatically set during deployment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     command: ["postgres", "-cshared_preload_libraries=pg_stat_statements"]
     environment:
       POSTGRES_USER: graph-node
-      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in environment (see .env.example)}
       POSTGRES_DB: graph-node
       POSTGRES_INITDB_ARGS: "-E UTF8 --lc-collate=C --lc-ctype=C"
     volumes:


### PR DESCRIPTION
## Why

`POSTGRES_PASSWORD: let-me-in` in this compose file was the entry vector for the 2026-05-15 → 2026-06-02 compromise of the graph-node-kava droplet. Combined with port 5432 bound to `0.0.0.0`, the postgres store was reachable + brute-forced + RCE'd via `COPY ... FROM PROGRAM`. Full incident report in DO support thread + tarball at `/root/incident-2026-06-02*.tar.gz` on the droplet.

## What

- `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?...}` — no default, compose exits if unset.
- `.env.example` placeholder flipped to a clear "generate per deploy" marker so nobody copy-pastes a weak literal.

## Deploy

On the droplet, before `docker compose up`:
```
echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)" >> /home/graph-user/.env
```
(graph-node-kava is already running with a hardened password set in compose directly; this PR is to make future deploys / new droplets safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)